### PR TITLE
Supported remapping the foreign keys of polymorphic associations

### DIFF
--- a/test/importer_test.rb
+++ b/test/importer_test.rb
@@ -140,4 +140,23 @@ class ImporterTest < ActiveSupport::TestCase
   
   
   
+  context "with polymorphic associations" do
+    setup do
+      plan do |import|
+        import.cats
+        import.owls
+        import.students
+      end
+    end
+    
+    should "preserve mappings" do
+      import!
+      assert_equal 2, account.students.map(&:pet).compact.count, "Expected two students to still be linked to their pets upon import"
+      assert_kind_of Owl, account.students.find_by_name("Harry Potter").pet, "Expected Harry's pet to be an Owl"
+      assert_kind_of Cat, account.students.find_by_name("Hermione Granger").pet, "Expected Harry's pet to be a Cat"
+    end
+  end
+  
+  
+  
 end

--- a/test/support/mock_data_source.rb
+++ b/test/support/mock_data_source.rb
@@ -3,9 +3,9 @@ class MockDataSource
   
   def students
     Enumerator.new do |e|
-      e.yield id: 456, name: "Harry Potter"
-      e.yield id: 457, name: "Ron Weasley"
-      e.yield id: 458, name: "Hermione Granger"
+      e.yield id: 456, name: "Harry Potter", pet_type: "Owl", pet_id: 901
+      e.yield id: 457, name: "Ron Weasley", pet_type: nil, pet_id: nil
+      e.yield id: 458, name: "Hermione Granger", pet_type: "Cat", pet_id: 901
     end
   end
   
@@ -37,6 +37,18 @@ class MockDataSource
     Enumerator.new do |e|
       e.yield id: 500, subject_id: 50, student_id: 457, value: "Acceptable"
       e.yield id: 501, subject_id: 51, student_id: 457, value: "Troll"
+    end
+  end
+  
+  def cats
+    Enumerator.new do |e|
+      e.yield id: 901, name: "Crookshanks"
+    end
+  end
+  
+  def owls
+    Enumerator.new do |e|
+      e.yield id: 901, name: "Hedwig"
     end
   end
   

--- a/test/support/mock_objects.rb
+++ b/test/support/mock_objects.rb
@@ -2,6 +2,7 @@ class Student < ActiveRecord::Base
   has_and_belongs_to_many :subjects
   has_many :grades
   has_many :parents
+  belongs_to :pet, polymorphic: true
   
   def report_card
     subjects.map do |subject|
@@ -34,4 +35,14 @@ class Account < ActiveRecord::Base
   has_many :subjects
   has_many :grades
   has_many :locations
+  has_many :cats
+  has_many :owls
+end
+
+class Cat < ActiveRecord::Base
+  has_one :student, as: :pet
+end
+
+class Owl < ActiveRecord::Base
+  has_one :student, as: :pet
 end

--- a/test/support/schema.rb
+++ b/test/support/schema.rb
@@ -8,6 +8,8 @@ ActiveRecord::Schema.define(:version => 1) do
     t.integer  "legacy_id"
     t.string   "name"
     t.string   "house"
+    t.string   "pet_type"
+    t.integer  "pet_id"
   end
   
   create_table "parents", :force => true do |t|
@@ -40,6 +42,18 @@ ActiveRecord::Schema.define(:version => 1) do
     t.integer  "student_id"
     t.integer  "legacy_id"
     t.string   "value"
+  end
+
+  create_table "owls", :force => true do |t|
+    t.integer  "account_id"
+    t.integer  "legacy_id"
+    t.string   "name"
+  end
+
+  create_table "cats", :force => true do |t|
+    t.integer  "account_id"
+    t.integer  "legacy_id"
+    t.string   "name"
   end
 
 end


### PR DESCRIPTION
The ID Map preserves the relationships between records in a relational database by remapping foreign keys.

The ID map can return the correct (new) value for a foreign key given two things:
- The foreign table (**dependency**)
- The foreign record's legacy ID (**legacy_id**)

To support polymorphic relationships, we needed to allow two scenarios:
1. Both values are present at compile time (when `CollectionImporter#prepare_mappings!` is called)
2. **dependency** is supposed at run time (when `CollectionImporter#remap_foreign_keys!` is called)

The current implementation only assumed the first scenario.
